### PR TITLE
Fixes phpmd rules' custom properties

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-/examples           export-ignore
 /tests              export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ $emailValidator->validate('test@email.com');
 | Provider                                        | Free Tier                   | Cost per validation | Unsupported Features |
 |-------------------------------------------------|-----------------------------|---------------------|----------------------|
 | [ValidatorPizza](https://www.validator.pizza/)  | 120 verifications per hour  | Free                | ```isHighRisk()```   |
-| [MailboxLayer](https://mailboxLayer.com/)       | 250 verifications per month | $0.002 to 0.0006    |                      |
-| [Mailgun](https://mailgun.com/)                 | 100 verifications per month | $0.01 to $0.008     | ```didYouMean()```*  |
+| [MailboxLayer](https://mailboxLayer.com/)       | 250 verifications per month | $0.002 to $0.0006   |                      |
+| [Mailgun](https://mailgun.com/)                 | 100 verifications per month | $0.010 to $0.008    | ```didYouMean()```*  |
 | [NeverBounce](https://neverbounce.com/)         | 1000 verifications          | $0.008 to $0.003    | ```isHighRisk()```   |
-| [Kickbox](https://kickbox.com/)                 | 100 verifications           | $0.01 to $0.004     |                      |
+| [Kickbox](https://kickbox.com/)                 | 100 verifications           | $0.010 to $0.004    |                      |
 
 \* the feature is documented but as for now, the API never returns a suggestion.
 

--- a/codesize.xml
+++ b/codesize.xml
@@ -12,7 +12,6 @@
     <exclude-pattern>vendor/*</exclude-pattern>
 
     <rule ref="rulesets/cleancode.xml" />
-    <rule ref="rulesets/codesize.xml" />
     <rule ref="rulesets/design.xml" />
     <rule ref="rulesets/naming.xml" />
     <rule ref="rulesets/unusedcode.xml" />


### PR DESCRIPTION
Fixes phpmd rules' custom properties.
Removes the /examples entry on .gitignore.
Adds zeros to prices to better visualization on README.md.