### PR TITLE
Updates mailgun prices and free tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ $emailValidator->validate('test@email.com');
 |-------------------------------------------------|-----------------------------|---------------------|----------------------|
 | [ValidatorPizza](https://www.validator.pizza/)  | 120 verifications per hour  | Free                | ```isHighRisk()```   |
 | [MailboxLayer](https://mailboxLayer.com/)       | 250 verifications per month | $0.002 to $0.0006   |                      |
-| [Mailgun](https://mailgun.com/)                 | 100 verifications per month | $0.010 to $0.008    | ```didYouMean()```*  |
 | [NeverBounce](https://neverbounce.com/)         | 1000 verifications          | $0.008 to $0.003    | ```isHighRisk()```   |
 | [Kickbox](https://kickbox.com/)                 | 100 verifications           | $0.010 to $0.004    |                      |
+| [Mailgun](https://mailgun.com/)                 | 0                           | $0.012 to $0.0025   | ```didYouMean()```*  |
 
 \* the feature is documented but as for now, the API never returns a suggestion.
 


### PR DESCRIPTION
Mailgun no longer offers a free tier for email validations.